### PR TITLE
ci+docs: validation workflow, contributor docs, dependabot, editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{sh,bash}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.cmd]
+end_of_line = crlf

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to Digital Innovation Agents
+
+Thanks for your interest in improving this project. This document outlines
+how to contribute changes to the skills, docs, hooks, or CI.
+
+## Ways to contribute
+
+- **Report an issue** — bugs, unclear docs, missing platform support
+- **Improve an existing skill** — tighter prose, better examples, fixed
+  references
+- **Add a new skill or phase artifact** — discuss first via an issue to avoid
+  duplicated work
+- **Docs** — VitePress pages under `docs/`, README, CHANGELOG
+- **Tooling** — install script, hooks, CI
+
+## Getting started
+
+```bash
+git clone https://github.com/pssah4/digital-innovation-agents.git
+cd digital-innovation-agents
+npm install         # VitePress docs
+npm run docs:dev    # local docs at http://localhost:5173
+```
+
+The skills themselves are plain Markdown with YAML frontmatter and need no
+build step — edit them directly under `skills/<phase>/SKILL.md`.
+
+## Skill structure
+
+Every skill lives in its own directory:
+
+```
+skills/<phase>/
+├── SKILL.md          # required — frontmatter + body
+├── references/       # optional — deep-dive material loaded on demand
+└── templates/        # optional — artifact scaffolds
+```
+
+`SKILL.md` requires frontmatter with at least `name` and `description`.
+`description` is the selector the model uses to decide when to invoke the
+skill — keep it specific and trigger-rich.
+
+```markdown
+---
+name: business-analyse
+description: Use when the problem space is unclear …
+---
+```
+
+Run the validator before opening a PR:
+
+```bash
+bash scripts/validate-skills.sh
+```
+
+CI runs the same validator plus link checks, JSON syntax validation, and
+shellcheck on every PR.
+
+## Commit messages
+
+Follow the existing style visible in `git log`:
+
+- `skills: …` — changes under `skills/`
+- `docs: …` — docs, README, CHANGELOG
+- `feat: …` — new capability
+- `fix: …` — bugfix
+- `chore(ci|deps): …` — tooling, dependencies
+
+Keep subjects short, lowercase, imperative. Body explains the *why* when the
+subject is not self-evident.
+
+## Pull requests
+
+1. Fork and create a topic branch off `main`.
+2. Make your changes — small, focused PRs review faster than big ones.
+3. Run local checks: `npm run docs:build`, `bash scripts/validate-skills.sh`.
+4. Fill in the PR template (summary, scope, test plan).
+5. Link related issues.
+
+A maintainer will review. Expect discussion — skills are user-facing prose,
+and wording matters.
+
+## Scope boundaries
+
+- **Stay focused.** Unrelated refactors belong in their own PR.
+- **Respect `_devprocess/`.** User-project artifacts never land in this
+  repo.
+- **Advisory, not enforcing.** Skills should guide, not block, user
+  workflows.
+
+## Code of conduct
+
+Be respectful, assume good intent, prefer concrete feedback over blanket
+criticism. Harassment is not tolerated.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the [MIT License](../LICENSE).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for your PR! Please fill in the sections below.
+Small, focused PRs review faster than big ones.
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes and why. -->
+
+## Scope
+
+- [ ] Skill(s) — `skills/<phase>/`
+- [ ] Docs — `docs/`, `README.md`, `CHANGELOG.md`
+- [ ] Tooling — install script, hooks, CI
+- [ ] Meta — repo config, templates, workflows
+
+## Checklist
+
+- [ ] Commit subject follows the `type: …` convention (`skills:`, `docs:`,
+      `feat:`, `fix:`, `chore:`)
+- [ ] Ran `bash scripts/validate-skills.sh` (if skills changed)
+- [ ] Ran `npm run docs:build` locally (if docs changed)
+- [ ] Updated `CHANGELOG.md` for user-visible changes
+- [ ] Linked related issues
+
+## Test plan
+
+<!--
+What did you do to verify the change?
+Commands run, pages visited, scenarios exercised.
+-->
+
+## Notes for reviewers
+
+<!-- Anything worth calling out: trade-offs, follow-ups, alternatives considered. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      vitepress:
+        patterns:
+          - "vitepress*"
+          - "mermaid*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,41 @@
+# Configuration for lychee link checker (https://lychee.cli.rs/)
+
+# Treat local files as relative to the repo root
+base = "."
+
+# Verbose output helps CI logs
+verbose = "info"
+
+# Reasonable timeout for slow upstreams
+timeout = 30
+
+# Don't fail on transient HTTP issues
+max_retries = 2
+retry_wait_time = 5
+
+# Skip checking anchors — authors frequently use semantic anchors that
+# differ from the rendered slug
+include_fragments = false
+
+# Accept these status codes as OK (GitHub rate-limits unauthenticated HEAD)
+accept = [200, 206, 301, 302, 304, 403, 429]
+
+# Exclusions for links we know are safe or not checkable in CI
+exclude = [
+  # Local dev URLs in docs examples
+  "^http://localhost",
+  "^http://127\\.0\\.0\\.1",
+  # Example placeholders
+  "example\\.com",
+  # GitHub user-attachment URLs — signed and not always reachable from CI
+  "github\\.com/user-attachments/",
+]
+
+# Only scan Markdown files (documentation)
+exclude_path = [
+  "node_modules/",
+  "docs/.vitepress/dist/",
+  "docs/.vitepress/cache/",
+  "backup/",
+  "package-lock.json",
+]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,83 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skills:
+    name: Skill frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate skills
+        run: bash scripts/validate-skills.sh
+
+  links:
+    name: Link check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .github/lychee.toml './**/*.md'
+          fail: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  json:
+    name: JSON syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate JSON files
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          failed=0
+          for f in \
+            .claude-plugin/plugin.json \
+            .claude-plugin/marketplace.json \
+            hooks/hooks.json \
+            hooks/hooks-cursor.json \
+            gemini-extension.json \
+            package.json; do
+            if [ -f "$f" ]; then
+              if node -e "JSON.parse(require('fs').readFileSync('$f','utf8'))"; then
+                echo "ok: $f"
+              else
+                echo "FAIL: $f" >&2
+                failed=1
+              fi
+            fi
+          done
+          exit $failed
+
+  shell:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+          scandir: .
+          ignore_paths: node_modules docs/.vitepress/dist docs/.vitepress/cache backup

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# validate-skills.sh
+# Validates the frontmatter of every skills/<phase>/SKILL.md:
+#   - file exists and has YAML frontmatter fenced by ---
+#   - `name` field present and matches the directory name
+#   - `description` field present, non-empty, and within reasonable length
+#
+# Exit code 0 on success, 1 on any validation failure.
+#
+# Intended for local pre-commit use and CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+# Anthropic recommends descriptions <=1024 chars; we allow headroom for
+# trigger-rich descriptions but still cap to catch runaway copy-paste.
+MAX_DESCRIPTION_LEN=2000
+MIN_DESCRIPTION_LEN=20
+
+failures=0
+checked=0
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "ERROR: skills directory not found at $SKILLS_DIR" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+validate_skill() {
+  local skill_file="$1"
+  local skill_dir
+  skill_dir="$(dirname "$skill_file")"
+  local expected_name
+  expected_name="$(basename "$skill_dir")"
+  local rel_path="${skill_file#"$REPO_ROOT/"}"
+
+  checked=$((checked + 1))
+
+  # Must start with frontmatter fence
+  local first_line
+  first_line="$(head -n 1 "$skill_file")"
+  if [ "$first_line" != "---" ]; then
+    fail "$rel_path: missing YAML frontmatter (first line is not '---')"
+    return
+  fi
+
+  # Extract frontmatter between the first two --- markers
+  local frontmatter
+  frontmatter="$(awk '
+    /^---[[:space:]]*$/ {
+      fence++
+      if (fence == 1) { next }
+      if (fence == 2) { exit }
+    }
+    fence == 1 { print }
+  ' "$skill_file")"
+
+  if [ -z "$frontmatter" ]; then
+    fail "$rel_path: empty or unterminated frontmatter"
+    return
+  fi
+
+  # Extract a top-level scalar field value, supporting:
+  #   key: value                (inline)
+  #   key: >                    (folded block scalar)
+  #     continuation lines
+  #   key: |                    (literal block scalar)
+  #     continuation lines
+  # Continuation lines are any lines indented more than column 0 until the
+  # next top-level key (non-indented) or the end of the frontmatter.
+  extract_field() {
+    local field="$1"
+    printf '%s\n' "$frontmatter" | awk -v field="$field" '
+      BEGIN {
+        key_re = "^" field ":"
+        found = 0
+        inline = ""
+        block = ""
+        collecting = 0
+      }
+      {
+        if (!found) {
+          if ($0 ~ key_re) {
+            found = 1
+            val = $0
+            sub(key_re, "", val)
+            sub(/^[[:space:]]+/, "", val)
+            sub(/[[:space:]]+$/, "", val)
+            if (val == ">" || val == ">-" || val == "|" || val == "|-") {
+              collecting = 1
+            } else {
+              inline = val
+            }
+            next
+          }
+        } else if (collecting) {
+          if ($0 ~ /^[[:space:]]/) {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            if (line == "") { next }
+            if (block == "") { block = line } else { block = block " " line }
+          } else if ($0 ~ /^[^[:space:]]/) {
+            exit
+          }
+        }
+      }
+      END {
+        if (inline != "") { print inline }
+        else { print block }
+      }
+    '
+  }
+
+  # name field
+  local name_value
+  name_value="$(extract_field "name")"
+  if [ -z "$name_value" ]; then
+    fail "$rel_path: missing 'name' in frontmatter"
+  elif [ "$name_value" != "$expected_name" ]; then
+    fail "$rel_path: name '$name_value' does not match directory '$expected_name'"
+  fi
+
+  # description field
+  local description_value
+  description_value="$(extract_field "description")"
+  if [ -z "$description_value" ]; then
+    fail "$rel_path: missing or empty 'description' in frontmatter"
+  else
+    local desc_len=${#description_value}
+    if [ "$desc_len" -lt "$MIN_DESCRIPTION_LEN" ]; then
+      fail "$rel_path: description too short ($desc_len chars, min $MIN_DESCRIPTION_LEN)"
+    fi
+    if [ "$desc_len" -gt "$MAX_DESCRIPTION_LEN" ]; then
+      fail "$rel_path: description too long ($desc_len chars, max $MAX_DESCRIPTION_LEN)"
+    fi
+  fi
+}
+
+while IFS= read -r -d '' skill_file; do
+  validate_skill "$skill_file"
+done < <(find "$SKILLS_DIR" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | sort -z)
+
+# Also verify every skill directory has a SKILL.md
+while IFS= read -r -d '' skill_dir; do
+  if [ ! -f "$skill_dir/SKILL.md" ]; then
+    rel="${skill_dir#"$REPO_ROOT/"}"
+    fail "$rel: directory has no SKILL.md"
+  fi
+done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+
+echo ""
+echo "Checked $checked skill file(s); $failures failure(s)."
+
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two additive, non-invasive improvements:

1. **Contributor documentation** — lowers the barrier for outside contributions.
2. **Validation CI** — catches the most common breakage sources (malformed skills, invalid JSON manifests, broken shell scripts, dead links) before merge.

No existing skill, doc, hook, or script is modified — everything in this PR is a new file.

## Scope

- [x] Meta — repo config, templates, workflows
- [x] Tooling — new validator script + CI

## What's in it

**Commit 1 — `chore: add contributor docs, PR template, dependabot, editorconfig`**

| File | Purpose |
| --- | --- |
| `.github/CONTRIBUTING.md` | Skill structure, commit convention, PR workflow, scope boundaries |
| `.github/PULL_REQUEST_TEMPLATE.md` | Summary / scope / checklist / test plan |
| `.github/dependabot.yml` | Weekly npm + github-actions updates (grouped for VitePress/Mermaid) |
| `.editorconfig` | Consistent indent / EOL / charset across macOS / Linux / Windows |

**Commit 2 — `ci: add validate workflow (skills, links, json, shell)`**

| File | Purpose |
| --- | --- |
| `scripts/validate-skills.sh` | Validates every `skills/<phase>/SKILL.md` has correct frontmatter — handles inline, folded (`>`), and literal (`\|`) YAML scalars |
| `.github/workflows/validate.yml` | 4 jobs: `skills`, `links`, `json`, `shell` |
| `.github/lychee.toml` | Link-checker config with sensible excludes (localhost, user-attachments, example.com) |

### CI jobs

- **skills** — runs `bash scripts/validate-skills.sh`; fails if any skill is missing a `SKILL.md`, has no frontmatter, the `name` field doesn't match the directory, or `description` is missing / empty / absurdly long
- **links** — lychee against every Markdown file (PR-only, `fail: false` — informational, doesn't block)
- **json** — validates syntax of `plugin.json`, `marketplace.json`, `hooks*.json`, `gemini-extension.json`, `package.json`
- **shell** — shellcheck against tracked shell scripts at `severity: warning`

## Test plan

- [x] `bash scripts/validate-skills.sh` passes locally against all 10 current skills (inline + folded + literal YAML scalars)
- [x] JSON validator passes locally against every tracked manifest
- [x] Branched from `upstream/main`; no merge conflicts
- [x] All files are new — no existing file touched

## Notes for reviewers

- **Markdownlint was deliberately omitted.** Running it against the current corpus produced ~100 style-only complaints (MD031/MD040/MD026/etc.) that are mostly noise. Better to leave this for a follow-up once the team decides on a shared markdown style.
- **Install-script hardening** (OS detection, dry-run mode) was out of scope for this PR because it would modify an existing script. Happy to open a separate PR if you'd like.
- The `skills` job will catch broken frontmatter on day one and prevent the most common skill-invocation failure mode in production.
- `links` job is non-blocking by design; promote to `fail: true` once the backlog of any reported dead links is cleared.

