### PR TITLE
docs: skill authoring style guide, versioning policy, artifact ownership matrix

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -90,6 +90,14 @@ const conceptsSidebar = [
       { text: 'Verification Gates', link: '/concepts/verification-gates' },
     ],
   },
+  {
+    text: 'Contributor reference',
+    items: [
+      { text: 'Skill Authoring Style Guide', link: '/concepts/skill-authoring' },
+      { text: 'Versioning Policy', link: '/concepts/versioning' },
+      { text: 'Artifact Ownership Matrix', link: '/concepts/artifact-ownership' },
+    ],
+  },
 ]
 
 export default withMermaid(

--- a/docs/concepts/artifact-ownership.md
+++ b/docs/concepts/artifact-ownership.md
@@ -1,0 +1,107 @@
+---
+title: Artifact Ownership Matrix
+description: Which skill writes which file, which skill reads it, and how artifacts flow through the V-Model.
+---
+
+# Artifact Ownership Matrix
+
+Every skill produces durable artifacts under `_devprocess/` in the
+user's project. This document is the shared map of **who writes
+what, and who reads it**. Two skills must never claim to own the same
+file -- when they do, one of them loses edits the other made.
+
+## Ownership principles
+
+1. **One writer per file.** A file has exactly one owning skill. Other
+   skills may read it, and may append via a clearly labelled section,
+   but the owner is responsible for structure and consistency.
+2. **Downstream reads, never mutates.** If `requirements-engineering`
+   reads the BA document, it does not edit it. If it needs to amend
+   something, it raises that back to `business-analyse`.
+3. **Writeback is explicit.** The `coding` skill updates design
+   artifacts (ADRs, plan-context, feature specs) when implementation
+   reveals the design needs to change. This is the one exception to
+   the "downstream reads, never mutates" rule, and it exists because
+   implementation is where reality meets intent.
+4. **Templates never get edited in place.** `templates/` files under
+   `skills/<phase>/` are scaffolds. The skill copies a template into
+   `_devprocess/` and edits the copy.
+
+## The matrix
+
+| Artifact (under `_devprocess/`) | Owner | Readers | Notes |
+| --- | --- | --- | --- |
+| `00_project/PROJECT.md` | `project-conventions` | all | Ground truth for project name, dirs, naming |
+| `01_business-analysis/BA-{PROJECT}.md` | `business-analyse` | `requirements-engineering`, `v-model-workflow`, `reverse-engineering` | Personas, HMW, value prop, hypotheses |
+| `01_business-analysis/method-cards/*.md` | `business-analyse` | `business-analyse` (next iteration) | One card per innovation method run |
+| `02_requirements-engineering/epics/EPIC-*.md` | `requirements-engineering` | `architecture`, `coding`, `testing` | One file per epic |
+| `02_requirements-engineering/features/FEATURE-*.md` | `requirements-engineering` | `architecture`, `coding`, `testing`, `security-audit` | One file per feature |
+| `02_requirements-engineering/architect-handoff.md` | `requirements-engineering` | `architecture` | Summary for the architect |
+| `03_architecture/ADR-*.md` | `architecture` | `coding`, `testing`, `security-audit` | MADR format |
+| `03_architecture/arc42.md` | `architecture` | `coding`, `testing`, `security-audit` | arc42 skeleton |
+| `03_architecture/plan-context.md` | `architecture` | `coding` | Context bridge to the implementation agent |
+| `04_coding/implementation-notes.md` | `coding` | `testing`, `security-audit` | What actually shipped vs. what was designed |
+| Updates to `03_architecture/*` during implementation | `coding` (writeback) | `architecture` (review sync) | See principle 3 |
+| `05_testing/test-plan.md` | `testing` | `security-audit` | Scope and coverage decisions |
+| `05_testing/results/*.md` | `testing` | `security-audit` | Run logs, not the code-under-test |
+| `06_security-audit/findings-*.md` | `security-audit` | `coding` (for fixes) | Prioritised, with remediation plan |
+| `06_security-audit/remediation-plan.md` | `security-audit` | `coding` | What to fix in which order |
+
+Numbers in the directory names match the V-Model phases; they make the
+order obvious when browsing the filesystem.
+
+## Orchestrators and bootstrap skills
+
+These skills do not own phase-scoped artifacts. They read them all.
+
+| Skill | What it reads | What it writes |
+| --- | --- | --- |
+| `v-model-workflow` | every phase artifact | nothing -- it dispatches |
+| `using-digital-innovation-agents` | nothing | nothing -- orientation only |
+| `reverse-engineering` | the codebase and existing docs | the full `_devprocess/` tree, marked as reverse-engineered |
+
+`reverse-engineering` is the exception: it is the only skill that
+legitimately writes into phases it does not own. Its outputs are
+marked "reverse-engineered" so downstream runs can tell the difference
+between a reverse-engineered BA and one that came from interviews.
+
+## When skills need to share state
+
+Use explicit handoff files, not shared ones:
+
+- `architect-handoff.md` is RE's last word to the architect, not a
+  shared scratch pad.
+- `plan-context.md` is the architect's last word to the implementer.
+- `implementation-notes.md` is the implementer's last word back up the
+  V.
+
+If you find yourself wanting a file that two skills both write, the
+usual fix is to split it into two files (one each) and have the
+reader concatenate mentally.
+
+## Working around ownership
+
+Sometimes a skill legitimately needs to annotate a file it does not
+own. The convention is a labelled append-only section at the end of
+the file:
+
+```markdown
+<!-- begin: security-audit annotations -->
+- finding SEC-2026-001 affects Feature FEAT-017
+- finding SEC-2026-014 affects Feature FEAT-023
+<!-- end: security-audit annotations -->
+```
+
+The owning skill preserves these sections on regeneration. If that
+contract is too heavy, it is a sign the information belongs in the
+annotating skill's own artifact instead.
+
+## Evolving the matrix
+
+This table is the single source of truth. When you add a skill or
+change an artifact path:
+
+1. Update the matrix in this file.
+2. Update the affected skills to match.
+3. Note the change in `CHANGELOG.md` (see
+   [versioning](./versioning.md) for classification).

--- a/docs/concepts/skill-authoring.md
+++ b/docs/concepts/skill-authoring.md
@@ -1,0 +1,147 @@
+---
+title: Skill Authoring Style Guide
+description: Conventions for writing and reviewing skills so that the whole set reads like one voice and triggers reliably.
+---
+
+# Skill Authoring Style Guide
+
+Skills in this repository are user-facing prose. A skill that reads badly
+or triggers unpredictably does more harm than no skill at all. This
+document is the shared baseline for authors and reviewers.
+
+## Anatomy of a skill
+
+Every skill is a directory under `skills/`:
+
+```
+skills/<phase>/
+├── SKILL.md          # required -- the skill itself
+├── references/       # optional -- long-form material loaded on demand
+└── templates/        # optional -- artifact scaffolds
+```
+
+`SKILL.md` has two parts: YAML frontmatter and Markdown body.
+
+### Frontmatter
+
+```yaml
+---
+name: <phase>
+description: >
+  One or two sentences describing what the skill does, followed by
+  trigger keywords the model can match against. Triggers matter more
+  than elegance; write for selection, not for reading.
+disable-model-invocation: false
+---
+```
+
+Rules:
+
+- `name` must equal the directory name. This is enforced by
+  `scripts/validate-skills.sh`.
+- `description` is the selector. Keep it under 2000 characters; aim
+  for 200--800. Include concrete trigger words the user would actually
+  type.
+- `disable-model-invocation: true` means "only run when explicitly
+  invoked" -- use for orchestrators (`v-model-workflow`) and skills
+  with side effects (`security-audit`).
+
+### Body
+
+Structure the body so a reviewer can skim:
+
+1. **Purpose.** One paragraph. Who calls this, why, what they get.
+2. **Inputs and outputs.** What the skill reads, what it writes. Be
+   explicit about paths under `_devprocess/`.
+3. **Workflow.** The steps the skill performs. Numbered lists beat
+   prose.
+4. **Quality gates.** What the skill refuses to do, what it escalates.
+5. **Keywords.** Bottom of file. Repeats the triggers so Ctrl-F finds them.
+
+## Voice
+
+- **Write for the operator, not the framework.** Second person ("you")
+  is fine when giving instructions to the model; avoid first-person
+  plural.
+- **Short sentences.** If a sentence has two "and"s, break it up.
+- **No buzzwords unless defined.** "Holistic", "synergy", "leverage"
+  without a specific meaning slow readers down. If a term is
+  methodology-specific (Jobs to be Done, ASR, NFR), link to where it
+  is defined.
+- **Advisory, not enforcing.** Skills guide; they do not gate. Respect
+  user opt-outs immediately.
+- **Stay in English.** The repository voice is English. Translated
+  variants may come later, but authors write in English so the whole
+  set reads consistently.
+
+## Length
+
+| Section | Budget | Why |
+| --- | --- | --- |
+| `description` | 200--1500 chars | long enough for triggers, short enough to stay in attention |
+| `SKILL.md` body | 200--600 lines | beyond this, split into `references/` |
+| `references/*.md` | unlimited | loaded on demand, not in selector |
+| `templates/*.md` | unlimited | user copies these; they are not read by the model |
+
+If a skill body exceeds the budget, the usual cause is prose where a
+list would do, or material that belongs in `references/`.
+
+## What goes in `references/`
+
+Anything the skill occasionally consults but does not always need:
+
+- Deep method descriptions (interview techniques, scoring matrices)
+- Example artifacts
+- Cross-platform adaptation notes
+- Historical context
+
+`SKILL.md` references these by relative path. The model loads them
+only when the current task needs them.
+
+## What goes in `templates/`
+
+Scaffolds the user (not the model) copies into `_devprocess/`:
+
+- Epic, Feature, Bugfix, Improvement, Issue templates
+- arc42 template, ADR template
+- Checklist templates
+
+Templates are artifacts, not instructions. Keep them filler-free so the
+user sees empty slots rather than stock phrases to edit away.
+
+## Review checklist
+
+Before approving a skill PR, check:
+
+- [ ] Frontmatter parses (`bash scripts/validate-skills.sh` passes)
+- [ ] `description` includes at least three concrete trigger words
+- [ ] Inputs and outputs are explicit (paths, file names, expected state)
+- [ ] Workflow steps can be performed top-to-bottom without jumping
+- [ ] Nothing in the body duplicates what `project-conventions`
+      already says
+- [ ] References and templates are linked, not pasted
+- [ ] Voice matches the existing set (short sentences, advisory tone)
+
+## Common mistakes
+
+**Descriptions that read well but trigger badly.** A polished sentence
+with no noun phrases the user would type is useless to the selector.
+Write *"Use when the user mentions 'ADR', 'arc42', 'architecture
+decision'"* explicitly.
+
+**Skills that do two jobs.** If you find yourself writing "this skill
+also...", split it. One skill, one purpose.
+
+**Instructions mixed with examples.** Put examples in `references/`
+and link them. Keep `SKILL.md` the minimum the model needs.
+
+**Copy-pasted phrasing across skills.** If three skills say the same
+thing about `_devprocess/` structure, that content belongs in
+`project-conventions` and the others link to it.
+
+## See also
+
+- [Versioning policy](./versioning.md) -- when a skill change is a
+  breaking change
+- [Artifact ownership](./artifact-ownership.md) -- which skill writes
+  which file

--- a/docs/concepts/versioning.md
+++ b/docs/concepts/versioning.md
@@ -1,0 +1,124 @@
+---
+title: Versioning Policy
+description: What counts as a breaking, additive, or cosmetic change to the Digital Innovation Agents skill set.
+---
+
+# Versioning Policy
+
+This project follows [Semantic Versioning](https://semver.org/): the
+public version is `MAJOR.MINOR.PATCH`. For a skill set, "public API"
+means more than code. It includes skill names, command names, the
+artifact contract, and the shape of the frontmatter.
+
+## What counts as the public surface
+
+| Surface | Example | Why it matters |
+| --- | --- | --- |
+| Skill names (directory names) | `/business-analyse`, `/architecture` | Users type these; install scripts pin these |
+| Skill `name` in frontmatter | `name: business-analyse` | Platforms route by this |
+| Produced artifact paths | `_devprocess/01_business-analysis/BA-*.md` | Downstream skills read these |
+| Template filenames | `EPIC-TEMPLATE.md`, `FEATURE-TEMPLATE.md` | Users fork these into projects |
+| Plugin manifest schema | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | Plugin marketplaces parse these |
+| CLI surface of `scripts/install-skills.sh` | flag names, exit codes | Users script around these |
+
+Everything else -- internal prose, wording of a `description`,
+references/ layout, commit messages -- is not part of the public
+surface. Change it freely.
+
+## Change classes
+
+### MAJOR -- breaking
+
+Bump `MAJOR` when existing users have to change something. Examples:
+
+- Rename or remove a skill (`/business-analyse` -> `/discovery`)
+- Rename or remove a command (`/v-model-workflow` -> `/v-workflow`)
+- Change the required frontmatter shape (rename `description` -> `summary`)
+- Move or rename a produced artifact (`BA-{PROJECT}.md` -> `business-analysis.md`)
+- Remove a template
+- Remove a CLI flag or change its semantics
+- Change the installation target directory
+- Drop support for a platform (Cursor, Codex, Gemini, Copilot, OpenCode)
+
+A MAJOR bump requires a migration note in `CHANGELOG.md` with
+before/after examples.
+
+### MINOR -- additive
+
+Bump `MINOR` when behaviour expands but nothing existing breaks.
+Examples:
+
+- Add a new skill
+- Add a new command
+- Add a new optional frontmatter field (e.g. `depends_on`)
+- Add a new CLI flag with a safe default
+- Add a new template file
+- Add a new platform manifest
+- Add a new artifact that nothing currently relies on
+
+### PATCH -- cosmetic or internal
+
+Bump `PATCH` for changes users are unlikely to notice. Examples:
+
+- Rewrite of a skill `description` that preserves triggers
+- Typo fixes, grammar, markdown formatting
+- Expand a reference or template body without changing its name
+- Internal refactor of scripts, CI, hooks
+- Docs-only changes under `docs/`
+- New CI job, updated linter config
+
+## Ambiguous cases
+
+**"I reworded the description to trigger better."** PATCH if the new
+wording is a superset of the old triggers (same keywords plus some
+extras). MINOR if it removes triggers users might have learned to rely
+on. MAJOR if you also renamed the skill.
+
+**"I moved content from `SKILL.md` to `references/`."** PATCH. The
+referenced file paths are not part of the public surface.
+
+**"I added a new optional frontmatter field."** MINOR. Existing skills
+that do not use it keep working.
+
+**"I tightened the validator and existing skills now fail."** MAJOR if
+the validator is part of CI and blocks merges; PATCH if it only warns.
+Either way, call it out in the PR.
+
+**"I added a step to the v-model-workflow orchestrator."** MINOR if
+the new step is optional or auto-detected; MAJOR if it changes the
+order of existing steps or requires new input.
+
+## Release cadence
+
+This project does not pre-commit to a release cadence. Releases happen
+when there is either (a) a batch of additive or cosmetic changes worth
+tagging, or (b) a single breaking change that needs a clean boundary.
+
+Pre-release markers (`-rc1`, `-beta.1`) are welcome for breaking
+changes -- they let early adopters test before the boundary moves.
+
+## The `CHANGELOG.md` contract
+
+Every PR that touches the public surface should add an entry to
+`CHANGELOG.md` under `## Unreleased`. Each release moves that block
+under a dated heading.
+
+Entry format:
+
+```markdown
+### Breaking
+- Renamed `/business-analyse` to `/discovery`
+  (migration: update any scripts that call `/business-analyse`)
+
+### Added
+- New `depends_on` frontmatter field on skills
+
+### Changed
+- `install-skills.sh` now asks for confirmation before overwrite
+
+### Fixed
+- ...
+```
+
+Short over lyrical. One line per change, with a parenthetical migration
+note when relevant.


### PR DESCRIPTION
## Summary

Three new concept pages under `docs/concepts/` that give contributors and reviewers a shared baseline. No skill, script, or manifest is touched.

## Why

The skill set grew to 10 and will keep growing. Right now there is no written answer to three questions that come up every time a new skill is reviewed:

1. **"Is this written the way the rest of the set is written?"**
2. **"Does this deserve a minor or a major version bump?"**
3. **"Wait, *two* skills are writing to `_devprocess/03_architecture/plan-context.md`?"**

Each of those is a recurring review discussion that is faster to resolve by pointing at a document than by re-arguing from first principles.

## What is in the PR

| File | Purpose |
| --- | --- |
| `docs/concepts/skill-authoring.md` | Anatomy of a skill, voice, length budgets, what belongs in `references/` vs `templates/`, and a concrete review checklist |
| `docs/concepts/versioning.md` | What counts as the public surface; MAJOR / MINOR / PATCH classification with edge cases; CHANGELOG.md format |
| `docs/concepts/artifact-ownership.md` | One-writer-per-file matrix across all ten skills, writeback exception for `coding`, and the `reverse-engineering` carve-out |
| `docs/.vitepress/config.mts` | New "Contributor reference" group in the Concepts sidebar |

## Test plan

- [x] `npm run docs:build` succeeds
- [x] Internal cross-links between the three new pages resolve
- [x] Sidebar shows the new group under Concepts
- [x] No existing doc is modified

## Notes for reviewers

- These are **descriptive, not prescriptive** for the current state. I wrote the ownership matrix from reading skill descriptions — please correct any row where I guessed the artifact path wrong, especially for `testing` and `security-audit` which I had least signal on.
- The versioning policy is my proposal. If the project leans toward a different convention (e.g. date-based), happy to reshape.
- The style guide section on "length budgets" is the one place I picked numbers out of the air. Worth calibrating against the actual corpus.