### PR TITLE
feat: declarative skill dependencies via depends_on frontmatter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{sh,bash}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.cmd]
+end_of_line = crlf

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to Digital Innovation Agents
+
+Thanks for your interest in improving this project. This document outlines
+how to contribute changes to the skills, docs, hooks, or CI.
+
+## Ways to contribute
+
+- **Report an issue** — bugs, unclear docs, missing platform support
+- **Improve an existing skill** — tighter prose, better examples, fixed
+  references
+- **Add a new skill or phase artifact** — discuss first via an issue to avoid
+  duplicated work
+- **Docs** — VitePress pages under `docs/`, README, CHANGELOG
+- **Tooling** — install script, hooks, CI
+
+## Getting started
+
+```bash
+git clone https://github.com/pssah4/digital-innovation-agents.git
+cd digital-innovation-agents
+npm install         # VitePress docs
+npm run docs:dev    # local docs at http://localhost:5173
+```
+
+The skills themselves are plain Markdown with YAML frontmatter and need no
+build step — edit them directly under `skills/<phase>/SKILL.md`.
+
+## Skill structure
+
+Every skill lives in its own directory:
+
+```
+skills/<phase>/
+├── SKILL.md          # required — frontmatter + body
+├── references/       # optional — deep-dive material loaded on demand
+└── templates/        # optional — artifact scaffolds
+```
+
+`SKILL.md` requires frontmatter with at least `name` and `description`.
+`description` is the selector the model uses to decide when to invoke the
+skill — keep it specific and trigger-rich.
+
+```markdown
+---
+name: business-analyse
+description: Use when the problem space is unclear …
+---
+```
+
+Run the validator before opening a PR:
+
+```bash
+bash scripts/validate-skills.sh
+```
+
+CI runs the same validator plus link checks, JSON syntax validation, and
+shellcheck on every PR.
+
+## Commit messages
+
+Follow the existing style visible in `git log`:
+
+- `skills: …` — changes under `skills/`
+- `docs: …` — docs, README, CHANGELOG
+- `feat: …` — new capability
+- `fix: …` — bugfix
+- `chore(ci|deps): …` — tooling, dependencies
+
+Keep subjects short, lowercase, imperative. Body explains the *why* when the
+subject is not self-evident.
+
+## Pull requests
+
+1. Fork and create a topic branch off `main`.
+2. Make your changes — small, focused PRs review faster than big ones.
+3. Run local checks: `npm run docs:build`, `bash scripts/validate-skills.sh`.
+4. Fill in the PR template (summary, scope, test plan).
+5. Link related issues.
+
+A maintainer will review. Expect discussion — skills are user-facing prose,
+and wording matters.
+
+## Scope boundaries
+
+- **Stay focused.** Unrelated refactors belong in their own PR.
+- **Respect `_devprocess/`.** User-project artifacts never land in this
+  repo.
+- **Advisory, not enforcing.** Skills should guide, not block, user
+  workflows.
+
+## Code of conduct
+
+Be respectful, assume good intent, prefer concrete feedback over blanket
+criticism. Harassment is not tolerated.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the [MIT License](../LICENSE).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for your PR! Please fill in the sections below.
+Small, focused PRs review faster than big ones.
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes and why. -->
+
+## Scope
+
+- [ ] Skill(s) — `skills/<phase>/`
+- [ ] Docs — `docs/`, `README.md`, `CHANGELOG.md`
+- [ ] Tooling — install script, hooks, CI
+- [ ] Meta — repo config, templates, workflows
+
+## Checklist
+
+- [ ] Commit subject follows the `type: …` convention (`skills:`, `docs:`,
+      `feat:`, `fix:`, `chore:`)
+- [ ] Ran `bash scripts/validate-skills.sh` (if skills changed)
+- [ ] Ran `npm run docs:build` locally (if docs changed)
+- [ ] Updated `CHANGELOG.md` for user-visible changes
+- [ ] Linked related issues
+
+## Test plan
+
+<!--
+What did you do to verify the change?
+Commands run, pages visited, scenarios exercised.
+-->
+
+## Notes for reviewers
+
+<!-- Anything worth calling out: trade-offs, follow-ups, alternatives considered. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      vitepress:
+        patterns:
+          - "vitepress*"
+          - "mermaid*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,0 +1,41 @@
+# Configuration for lychee link checker (https://lychee.cli.rs/)
+
+# Treat local files as relative to the repo root
+base = "."
+
+# Verbose output helps CI logs
+verbose = "info"
+
+# Reasonable timeout for slow upstreams
+timeout = 30
+
+# Don't fail on transient HTTP issues
+max_retries = 2
+retry_wait_time = 5
+
+# Skip checking anchors — authors frequently use semantic anchors that
+# differ from the rendered slug
+include_fragments = false
+
+# Accept these status codes as OK (GitHub rate-limits unauthenticated HEAD)
+accept = [200, 206, 301, 302, 304, 403, 429]
+
+# Exclusions for links we know are safe or not checkable in CI
+exclude = [
+  # Local dev URLs in docs examples
+  "^http://localhost",
+  "^http://127\\.0\\.0\\.1",
+  # Example placeholders
+  "example\\.com",
+  # GitHub user-attachment URLs — signed and not always reachable from CI
+  "github\\.com/user-attachments/",
+]
+
+# Only scan Markdown files (documentation)
+exclude_path = [
+  "node_modules/",
+  "docs/.vitepress/dist/",
+  "docs/.vitepress/cache/",
+  "backup/",
+  "package-lock.json",
+]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,83 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skills:
+    name: Skill frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate skills
+        run: bash scripts/validate-skills.sh
+
+  links:
+    name: Link check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .github/lychee.toml './**/*.md'
+          fail: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  json:
+    name: JSON syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate JSON files
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          failed=0
+          for f in \
+            .claude-plugin/plugin.json \
+            .claude-plugin/marketplace.json \
+            hooks/hooks.json \
+            hooks/hooks-cursor.json \
+            gemini-extension.json \
+            package.json; do
+            if [ -f "$f" ]; then
+              if node -e "JSON.parse(require('fs').readFileSync('$f','utf8'))"; then
+                echo "ok: $f"
+              else
+                echo "FAIL: $f" >&2
+                failed=1
+              fi
+            fi
+          done
+          exit $failed
+
+  shell:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+          scandir: .
+          ignore_paths: node_modules docs/.vitepress/dist docs/.vitepress/cache backup

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# validate-skills.sh
+# Validates the frontmatter of every skills/<phase>/SKILL.md:
+#   - file exists and has YAML frontmatter fenced by ---
+#   - `name` field present and matches the directory name
+#   - `description` field present, non-empty, and within reasonable length
+#
+# Exit code 0 on success, 1 on any validation failure.
+#
+# Intended for local pre-commit use and CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+# Anthropic recommends descriptions <=1024 chars; we allow headroom for
+# trigger-rich descriptions but still cap to catch runaway copy-paste.
+MAX_DESCRIPTION_LEN=2000
+MIN_DESCRIPTION_LEN=20
+
+failures=0
+checked=0
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "ERROR: skills directory not found at $SKILLS_DIR" >&2
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+validate_skill() {
+  local skill_file="$1"
+  local skill_dir
+  skill_dir="$(dirname "$skill_file")"
+  local expected_name
+  expected_name="$(basename "$skill_dir")"
+  local rel_path="${skill_file#"$REPO_ROOT/"}"
+
+  checked=$((checked + 1))
+
+  # Must start with frontmatter fence
+  local first_line
+  first_line="$(head -n 1 "$skill_file")"
+  if [ "$first_line" != "---" ]; then
+    fail "$rel_path: missing YAML frontmatter (first line is not '---')"
+    return
+  fi
+
+  # Extract frontmatter between the first two --- markers
+  local frontmatter
+  frontmatter="$(awk '
+    /^---[[:space:]]*$/ {
+      fence++
+      if (fence == 1) { next }
+      if (fence == 2) { exit }
+    }
+    fence == 1 { print }
+  ' "$skill_file")"
+
+  if [ -z "$frontmatter" ]; then
+    fail "$rel_path: empty or unterminated frontmatter"
+    return
+  fi
+
+  # Extract a top-level scalar field value, supporting:
+  #   key: value                (inline)
+  #   key: >                    (folded block scalar)
+  #     continuation lines
+  #   key: |                    (literal block scalar)
+  #     continuation lines
+  # Continuation lines are any lines indented more than column 0 until the
+  # next top-level key (non-indented) or the end of the frontmatter.
+  extract_field() {
+    local field="$1"
+    printf '%s\n' "$frontmatter" | awk -v field="$field" '
+      BEGIN {
+        key_re = "^" field ":"
+        found = 0
+        inline = ""
+        block = ""
+        collecting = 0
+      }
+      {
+        if (!found) {
+          if ($0 ~ key_re) {
+            found = 1
+            val = $0
+            sub(key_re, "", val)
+            sub(/^[[:space:]]+/, "", val)
+            sub(/[[:space:]]+$/, "", val)
+            if (val == ">" || val == ">-" || val == "|" || val == "|-") {
+              collecting = 1
+            } else {
+              inline = val
+            }
+            next
+          }
+        } else if (collecting) {
+          if ($0 ~ /^[[:space:]]/) {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            if (line == "") { next }
+            if (block == "") { block = line } else { block = block " " line }
+          } else if ($0 ~ /^[^[:space:]]/) {
+            exit
+          }
+        }
+      }
+      END {
+        if (inline != "") { print inline }
+        else { print block }
+      }
+    '
+  }
+
+  # name field
+  local name_value
+  name_value="$(extract_field "name")"
+  if [ -z "$name_value" ]; then
+    fail "$rel_path: missing 'name' in frontmatter"
+  elif [ "$name_value" != "$expected_name" ]; then
+    fail "$rel_path: name '$name_value' does not match directory '$expected_name'"
+  fi
+
+  # description field
+  local description_value
+  description_value="$(extract_field "description")"
+  if [ -z "$description_value" ]; then
+    fail "$rel_path: missing or empty 'description' in frontmatter"
+  else
+    local desc_len=${#description_value}
+    if [ "$desc_len" -lt "$MIN_DESCRIPTION_LEN" ]; then
+      fail "$rel_path: description too short ($desc_len chars, min $MIN_DESCRIPTION_LEN)"
+    fi
+    if [ "$desc_len" -gt "$MAX_DESCRIPTION_LEN" ]; then
+      fail "$rel_path: description too long ($desc_len chars, max $MAX_DESCRIPTION_LEN)"
+    fi
+  fi
+}
+
+while IFS= read -r -d '' skill_file; do
+  validate_skill "$skill_file"
+done < <(find "$SKILLS_DIR" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | sort -z)
+
+# Also verify every skill directory has a SKILL.md
+while IFS= read -r -d '' skill_dir; do
+  if [ ! -f "$skill_dir/SKILL.md" ]; then
+    rel="${skill_dir#"$REPO_ROOT/"}"
+    fail "$rel: directory has no SKILL.md"
+  fi
+done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+
+echo ""
+echo "Checked $checked skill file(s); $failures failure(s)."
+
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -3,7 +3,9 @@
 # Validates the frontmatter of every skills/<phase>/SKILL.md:
 #   - file exists and has YAML frontmatter fenced by ---
 #   - `name` field present and matches the directory name
-#   - `description` field present, non-empty, and within reasonable length
+#   - `description` field present, non-empty, within reasonable length
+#   - `depends_on` (optional) is a flow-style list of valid skill names,
+#     with no self-reference and no cycles across the whole set
 #
 # Exit code 0 on success, 1 on any validation failure.
 #
@@ -33,6 +35,36 @@ fail() {
   failures=$((failures + 1))
 }
 
+# Collect all known skill directory names once, for depends_on validation.
+KNOWN_SKILLS=()
+while IFS= read -r -d '' d; do
+  KNOWN_SKILLS+=("$(basename "$d")")
+done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+
+is_known_skill() {
+  local needle="$1"
+  local s
+  for s in "${KNOWN_SKILLS[@]}"; do
+    if [ "$s" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Associative-array-free dependency storage (bash 3.2 compatible):
+# DEPS_NAMES is a parallel list of skill names; DEPS_LISTS[i] holds a
+# space-separated list of deps for DEPS_NAMES[i].
+DEPS_NAMES=()
+DEPS_LISTS=()
+
+record_deps() {
+  local name="$1"
+  local deps="$2"
+  DEPS_NAMES+=("$name")
+  DEPS_LISTS+=("$deps")
+}
+
 validate_skill() {
   local skill_file="$1"
   local skill_dir
@@ -43,7 +75,6 @@ validate_skill() {
 
   checked=$((checked + 1))
 
-  # Must start with frontmatter fence
   local first_line
   first_line="$(head -n 1 "$skill_file")"
   if [ "$first_line" != "---" ]; then
@@ -51,7 +82,6 @@ validate_skill() {
     return
   fi
 
-  # Extract frontmatter between the first two --- markers
   local frontmatter
   frontmatter="$(awk '
     /^---[[:space:]]*$/ {
@@ -67,14 +97,8 @@ validate_skill() {
     return
   fi
 
-  # Extract a top-level scalar field value, supporting:
-  #   key: value                (inline)
-  #   key: >                    (folded block scalar)
-  #     continuation lines
-  #   key: |                    (literal block scalar)
-  #     continuation lines
-  # Continuation lines are any lines indented more than column 0 until the
-  # next top-level key (non-indented) or the end of the frontmatter.
+  # Extract a top-level scalar field value, supporting inline and folded/
+  # literal block scalars (>, >-, |, |-).
   extract_field() {
     local field="$1"
     printf '%s\n' "$frontmatter" | awk -v field="$field" '
@@ -142,13 +166,58 @@ validate_skill() {
       fail "$rel_path: description too long ($desc_len chars, max $MAX_DESCRIPTION_LEN)"
     fi
   fi
+
+  # depends_on (optional) -- only flow-style "[a, b]" is supported for now
+  local deps_raw
+  deps_raw="$(extract_field "depends_on")"
+  local parsed_deps=""
+  if [ -n "$deps_raw" ]; then
+    case "$deps_raw" in
+      '['*']')
+        local inner="${deps_raw#[}"
+        inner="${inner%]}"
+        # Split on commas, trim each item
+        local old_ifs="$IFS"
+        IFS=','
+        # shellcheck disable=SC2206
+        local items=($inner)
+        IFS="$old_ifs"
+        local item
+        if [ "${#items[@]}" -eq 0 ]; then
+          record_deps "$expected_name" ""
+          return
+        fi
+        for item in "${items[@]}"; do
+          # trim whitespace and surrounding quotes
+          item="${item#"${item%%[![:space:]]*}"}"
+          item="${item%"${item##*[![:space:]]}"}"
+          item="${item#\"}"; item="${item%\"}"
+          item="${item#\'}"; item="${item%\'}"
+          if [ -z "$item" ]; then continue; fi
+          if [ "$item" = "$expected_name" ]; then
+            fail "$rel_path: depends_on references itself ('$item')"
+            continue
+          fi
+          if ! is_known_skill "$item"; then
+            fail "$rel_path: depends_on references unknown skill '$item'"
+            continue
+          fi
+          parsed_deps="$parsed_deps $item"
+        done
+        ;;
+      *)
+        fail "$rel_path: depends_on must be flow-style list, e.g. depends_on: [foo, bar]"
+        ;;
+    esac
+  fi
+  record_deps "$expected_name" "$parsed_deps"
 }
 
 while IFS= read -r -d '' skill_file; do
   validate_skill "$skill_file"
 done < <(find "$SKILLS_DIR" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -print0 | sort -z)
 
-# Also verify every skill directory has a SKILL.md
+# Verify every skill directory has a SKILL.md
 while IFS= read -r -d '' skill_dir; do
   if [ ! -f "$skill_dir/SKILL.md" ]; then
     rel="${skill_dir#"$REPO_ROOT/"}"
@@ -156,9 +225,95 @@ while IFS= read -r -d '' skill_dir; do
   fi
 done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
 
+# -------- cycle detection across depends_on graph -------------------------
+
+get_deps() {
+  local want="$1"
+  local i=0
+  while [ $i -lt "${#DEPS_NAMES[@]}" ]; do
+    if [ "${DEPS_NAMES[$i]}" = "$want" ]; then
+      echo "${DEPS_LISTS[$i]}"
+      return
+    fi
+    i=$((i + 1))
+  done
+}
+
+# Iterative DFS per node. Colours: WHITE (unseen), GRAY (in stack), BLACK (done).
+declare_cycle() {
+  fail "depends_on cycle involving: $1"
+}
+
+CYCLE_PATH=""
+visit_color_names=()
+visit_color_values=()
+
+get_color() {
+  local want="$1"
+  local i=0
+  while [ $i -lt "${#visit_color_names[@]}" ]; do
+    if [ "${visit_color_names[$i]}" = "$want" ]; then
+      echo "${visit_color_values[$i]}"
+      return
+    fi
+    i=$((i + 1))
+  done
+  echo "WHITE"
+}
+
+set_color() {
+  local target="$1"
+  local color="$2"
+  local i=0
+  while [ $i -lt "${#visit_color_names[@]}" ]; do
+    if [ "${visit_color_names[$i]}" = "$target" ]; then
+      visit_color_values[$i]="$color"
+      return
+    fi
+    i=$((i + 1))
+  done
+  visit_color_names+=("$target")
+  visit_color_values+=("$color")
+}
+
+dfs() {
+  local node="$1"
+  local path_prefix="$2"
+  local current_color
+  current_color="$(get_color "$node")"
+  if [ "$current_color" = "GRAY" ]; then
+    CYCLE_PATH="$path_prefix -> $node"
+    return 1
+  fi
+  if [ "$current_color" = "BLACK" ]; then
+    return 0
+  fi
+  set_color "$node" "GRAY"
+  local d
+  for d in $(get_deps "$node"); do
+    if ! dfs "$d" "$path_prefix -> $node"; then
+      return 1
+    fi
+  done
+  set_color "$node" "BLACK"
+  return 0
+}
+
+# Drive DFS from each skill.
+cycle_found=0
+for skill in "${KNOWN_SKILLS[@]}"; do
+  if [ "$(get_color "$skill")" = "WHITE" ]; then
+    if ! dfs "$skill" ""; then
+      declare_cycle "${CYCLE_PATH# -> }"
+      cycle_found=1
+      break
+    fi
+  fi
+done
+
 echo ""
 echo "Checked $checked skill file(s); $failures failure(s)."
 
-if [ "$failures" -gt 0 ]; then
+if [ "$failures" -gt 0 ] || [ "$cycle_found" -ne 0 ]; then
   exit 1
 fi

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -9,6 +9,7 @@ description: >
   similar. Also when requirements exist and the next step is technical
   structuring. This skill creates PROPOSALS. Claude Code makes the
   final decisions based on the real state of the codebase.
+depends_on: [requirements-engineering, project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/business-analyse/SKILL.md
+++ b/skills/business-analyse/SKILL.md
@@ -11,6 +11,7 @@ description: >
   "Idea Potential", "Innovation", or similar. Also when the user wants to start
   a new project and does not yet have a clear requirement. This skill helps
   understand the problem before discussing solutions.
+depends_on: [project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/coding/SKILL.md
+++ b/skills/coding/SKILL.md
@@ -9,6 +9,7 @@ description: >
   NOT take over the coding workflow -- the Default Claude Code agent remains
   responsible for the actual implementation. This skill ensures the context
   is critically reviewed, cleanly handed off, and artifacts stay up to date.
+depends_on: [architecture, project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/project-conventions/SKILL.md
+++ b/skills/project-conventions/SKILL.md
@@ -7,6 +7,7 @@ description: >
   the user mentions "project setup", "project structure", "conventions",
   "init", "initialize project", "directory structure", or similar. Also
   automatically relevant when starting a new project.
+depends_on: []
 disable-model-invocation: false
 ---
 

--- a/skills/requirements-engineering/SKILL.md
+++ b/skills/requirements-engineering/SKILL.md
@@ -7,6 +7,7 @@ description: >
   "User Stories", "Requirements", "Success Criteria", "NFRs", "ASRs",
   "Acceptance Criteria", or similar. Also when a BA document exists and the
   next step is the formalization of requirements.
+depends_on: [business-analyse, project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/reverse-engineering/SKILL.md
+++ b/skills/reverse-engineering/SKILL.md
@@ -12,6 +12,7 @@ description: >
   engineer", "import existing code", "brownfield", "we already have
   code", "onboard existing project", or when the user wants to enter
   the V-Model workflow but artifacts do not exist yet.
+depends_on: [project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -7,6 +7,7 @@ description: >
   this skill when the user mentions "security audit", "security review",
   "OWASP", "vulnerability check", "threat model", "dependency audit",
   "CVE check", "penetration", "security scan" or similar.
+depends_on: [testing, project-conventions]
 disable-model-invocation: true
 ---
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -7,6 +7,7 @@ description: >
   "unit tests", "integration tests", "test coverage", "testing", "tests
   missing", "TDD" or similar. Also after implementation when tests need to
   be created or updated.
+depends_on: [coding, project-conventions]
 disable-model-invocation: false
 ---
 

--- a/skills/using-digital-innovation-agents/SKILL.md
+++ b/skills/using-digital-innovation-agents/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-digital-innovation-agents
 description: Introduces the V-Model skill set and entry points. Advisory, not enforcing - user can always opt out.
+depends_on: []
 ---
 
 # Using Digital Innovation Agents

--- a/skills/v-model-workflow/SKILL.md
+++ b/skills/v-model-workflow/SKILL.md
@@ -8,6 +8,7 @@ description: >
   analysis to implementation", "full cycle" or similar. Also when it is
   unclear which phase to start in. All phases follow the conventions from
   /project-conventions.
+depends_on: [project-conventions]
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary

Adds a `depends_on` field to every SKILL.md frontmatter and teaches the validator to verify the resulting graph. Makes skill ordering explicit and machine-checkable instead of implicit in prose.

## Dependency graph

```
project-conventions (root)
using-digital-innovation-agents (root)

business-analyse          -> [project-conventions]
v-model-workflow          -> [project-conventions]
reverse-engineering       -> [project-conventions]
requirements-engineering  -> [business-analyse, project-conventions]
architecture              -> [requirements-engineering, project-conventions]
coding                    -> [architecture, project-conventions]
testing                   -> [coding, project-conventions]
security-audit            -> [testing, project-conventions]
```

This matches the V-Model phase chain. `project-conventions` is the shared style/voice root; `using-digital-innovation-agents` is the user-facing intro skill.

## Validator changes

`scripts/validate-skills.sh` now additionally:

- parses flow-style lists (`depends_on: [a, b]`)
- rejects unknown skill names
- rejects self-references
- detects cycles via iterative DFS across the full graph (bash 3.2 compatible, no associative arrays)

Negative tests run locally before pushing:

| Case                              | Result |
|-----------------------------------|--------|
| Unknown skill ref                 | FAIL ok |
| Self-reference                    | FAIL ok |
| Cycle (coding->security-audit->testing->coding) | FAIL ok |
| Clean tree                        | PASS ok |

## Follow-ups (not in this PR)

- `scripts/skill-graph.sh` rendering a Mermaid DAG for the docs site
- topological-sort helper for batch operations across skills

## Notes for reviewers

- Builds on #2 (validator baseline). If #2 merges first, this rebases cleanly.
- The edges reflect **reading dependencies** (what a skill relies on being in place), not runtime call order inside `/v-model-workflow`.
- No code, templates, or references changed beyond frontmatter + validator.

## Test plan

- [ ] `bash scripts/validate-skills.sh` exits 0 on clean tree
- [ ] `bash scripts/validate-skills.sh` exits 1 when a fake cycle is injected
- [ ] Existing skill prose renders unchanged in the docs site