### PR TITLE
ci: build docs on pull requests, upload as downloadable artifact

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,56 @@
+name: docs-preview
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/docs-preview.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Upload build as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview-${{ github.event.pull_request.number }}
+          path: docs/.vitepress/dist
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summary
+        run: |
+          {
+            echo "## Docs preview built"
+            echo ""
+            echo "Download the \`docs-preview-${{ github.event.pull_request.number }}\` artifact"
+            echo "from this run and open \`index.html\` locally (or serve with any static server)."
+            echo ""
+            echo "Build output size:"
+            du -sh docs/.vitepress/dist | awk '{print "- "$1}'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Every PR that touches the docs now gets a VitePress build in CI. The result is attached to the run as a downloadable artifact, so reviewers can spot-check the rendered site before merge without spinning up a local dev server.

## What it does

- Triggers on PRs that change `docs/**`, `package.json`, `package-lock.json`, or the workflow itself
- Installs with `npm ci` (falls back to `npm install`)
- Runs `npm run docs:build` (VitePress with Mermaid)
- Uploads `docs/.vitepress/dist` as `docs-preview-<PR#>`, retention 14 days
- Writes a short summary in the Actions run (artifact name + build size)

## What it deliberately does NOT do

- No Pages deploy, no hosted environment, no fork secrets (read-only `contents: read`)
- No comment-bot -- nothing writes to PRs from CI
- Concurrency: `docs-preview-<ref>` with cancel-in-progress so pushing new commits abandons the stale build instead of queueing

## Why

Today a docs-only PR has to either be merged and reverted, cloned and built locally, or trusted based on the diff. This gives a middle path: the reviewer clicks Actions -> Artifacts -> Download -> open `index.html`.

Side effect: broken Mermaid, bad Markdown, or a VitePress config regression fails CI before it hits `main`.

## Test plan

- [ ] Push a no-op docs change to a branch off this one, watch the workflow run
- [ ] Confirm the artifact is downloadable and `index.html` renders
- [ ] Confirm a deliberately broken Mermaid block fails the build