### PR TITLE
fix(consistency-check): accept 3-digit ADR/EPIC/PLAN IDs

### DIFF
--- a/tools/consistency-check.py
+++ b/tools/consistency-check.py
@@ -303,7 +303,7 @@ def check_adr_abstraction(adr_files: Iterable[Path]) -> list[Finding]:
 
 
 BACKLOG_ROW_RE = re.compile(r"^\|\s*([A-Z]+(?:-\d+){1,3})\s*\|", re.MULTILINE)
-BACKLOG_EPIC_HEADER_RE = re.compile(r"^###\s+(EPIC-\d{2})", re.MULTILINE)
+BACKLOG_EPIC_HEADER_RE = re.compile(r"^###\s+(EPIC-\d{2,3})", re.MULTILINE)
 
 
 def parse_backlog_ids() -> set[str]:
@@ -321,9 +321,9 @@ ID_PATTERNS = [
     ("FIX", re.compile(r"^(FIX-\d{2}-\d{2}-\d{2})(?:-|$)")),
     ("IMP", re.compile(r"^(IMP-\d{2}-\d{2}-\d{2})(?:-|$)")),
     ("FEAT", re.compile(r"^(FEAT-\d{2}-\d{2})(?:-|$)")),
-    ("EPIC", re.compile(r"^(EPIC-\d{2})(?:-|$)")),
-    ("ADR", re.compile(r"^(ADR-\d{2})(?:-|$)")),
-    ("PLAN", re.compile(r"^(PLAN-\d{2})(?:-|$)")),
+    ("EPIC", re.compile(r"^(EPIC-\d{2,3})(?:-|$)")),
+    ("ADR", re.compile(r"^(ADR-\d{2,3})(?:-|$)")),
+    ("PLAN", re.compile(r"^(PLAN-\d{2,3})(?:-|$)")),
 ]
 
 
@@ -868,7 +868,7 @@ def check_detail_file_status_drift() -> list[Finding]:
 
 
 BACKLOG_ID_ROW_RE = re.compile(
-    r"^\|\s*((?:FEAT|FIX|IMP|ADR|PLAN)-\d{2}(?:-\d{2}){0,2})\s*\|"
+    r"^\|\s*((?:FEAT|FIX|IMP)-\d{2}(?:-\d{2}){1,2}|(?:ADR|PLAN)-\d{2,3})\s*\|"
 )
 
 


### PR DESCRIPTION
## Summary

- Widens the ID-prefix regex in `tools/consistency-check.py` from `\d{2}` to `\d{2,3}` for the standalone-ID classes (ADR, EPIC, PLAN), at three call sites.
- Restructures `BACKLOG_ID_ROW_RE` into an alternation so FEAT/FIX/IMP composite IDs keep their `-\d{2}` suffix requirement.
- FEAT/FIX/IMP prefixes left at `\d{2}` deliberately — a 3-digit epic-prefix is a data-shape change, not part of this fix.

## Bug

Once a project crosses ADR-100 (or EPIC-100, PLAN-100), the script's `^(ADR-\d{2})(?:-|$)` fails to capture the file stem and `parse_artifact_id` returns `None`. The Mode A `orphan-backlog-row` check then flags every BACKLOG row whose 3-digit ID it can't map back to a file, producing false-positive findings even when the files exist and are referenced.

Concrete reproducer in the wild: `obsidian-agent` has ADR-100..123 and Mode A reported 23 false-positive `orphan-backlog-row` findings. After the patch: 0 false positives.

## Diff sites (5 lines total)

1. `BACKLOG_EPIC_HEADER_RE` — parses `### EPIC-NN` section headers in BACKLOG.md.
2. `ID_PATTERNS` — file-stem parser (EPIC, ADR, PLAN). The downstream consumer for `parse_artifact_id`.
3. `BACKLOG_ID_ROW_RE` — used by the N-19 ID-uniqueness check. Split into alternation: composite IDs keep `\d{2}(?:-\d{2}){1,2}`, standalone ADR/PLAN accept `\d{2,3}`.

## Test plan

- [x] `python3 -m py_compile tools/consistency-check.py` — clean
- [x] Smoke test against `obsidian-agent` (122 ADR files, IDs 01..123): 0 findings after fix, 23 false-positive orphans before fix
- [ ] Run against a project that stays below 100 in every ID class to confirm no behaviour change (test on the DIA repo itself when CI is available)

## Note

The repo's `tools/git-hooks/pre-commit` template and `tools/install-git-hooks.sh` copy this script to `.git/hooks-data/` in target projects, so the fix flows through to consuming projects on next install. Existing local copies under target projects' `.git/hooks-data/` are not auto-updated; users who patched locally (e.g. `obsilo-agent`'s BACKLOG DEBT-CC-2026-05-12) can revert to the upstream version after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)